### PR TITLE
Fixed dates to match new input file

### DIFF
--- a/src/cablab/providers/c_emissions.py
+++ b/src/cablab/providers/c_emissions.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import timedelta, datetime
 import os
 
 import numpy

--- a/src/cablab/providers/c_emissions.py
+++ b/src/cablab/providers/c_emissions.py
@@ -7,7 +7,7 @@ import netCDF4
 from cablab import BaseCubeSourceProvider
 from cablab.util import NetCDFDatasetCache, aggregate_images
 
-VAR_NAME = 'C_Emissions'
+VAR_NAME = 'Emission'
 
 
 class CEmissionsProvider(BaseCubeSourceProvider):
@@ -85,19 +85,18 @@ class CEmissionsProvider(BaseCubeSourceProvider):
         source_time_ranges = []
         file_names = os.listdir(self.dir_path)
         for file_name in file_names:
-            if file_name.endswith('.nc.gz'):
-                file = os.path.join(self.dir_path, file_name)
-                dataset = self.dataset_cache.get_dataset(file)
-                time = dataset.variables['time']
-                # dates = netCDF4.num2date(time[:], time.units, calendar=time.calendar)
-                dates = netCDF4.num2date(time[:], 'days since 1582-10-15 00:00', calendar='gregorian')
-                self.dataset_cache.close_dataset(file)
-                n = len(dates)
-                for i in range(n):
-                    t1 = dates[i]
-                    if i < n - 1:
-                        t2 = dates[i + 1]
-                    else:
-                        t2 = t1 + timedelta(days=31)  # assuming it's December
-                    source_time_ranges.append((t1, t2, file, i))
+            file = os.path.join(self.dir_path, file_name)
+            dataset = self.dataset_cache.get_dataset(file)
+            time = dataset.variables['time']
+            # dates = netCDF4.num2date(time[:], time.units, calendar=time.calendar)
+            dates=[datetime(yr,mo,1) for yr in range(2001,2011) for mo in range(1,13)]
+            self.dataset_cache.close_dataset(file)
+            n = len(dates)
+            for i in range(n):
+                t1 = dates[i]
+                if i < n - 1:
+                    t2 = dates[i + 1]
+                else:
+                    t2 = t1 + timedelta(days=31)  # assuming it's December
+                source_time_ranges.append((t1, t2, file, i))
         self.source_time_ranges = sorted(source_time_ranges, key=lambda item: item[0])

--- a/test/providers/test_c_emissions.py
+++ b/test/providers/test_c_emissions.py
@@ -6,7 +6,7 @@ from cablab import CubeConfig
 from cablab.providers.c_emissions import CEmissionsProvider
 from cablab.util import Config
 
-SOURCE_DIR = Config.instance().get_cube_source_path('Emissions')
+SOURCE_DIR = Config.instance().get_cube_source_path('Fire_C_Emissions')
 
 
 class CEmissionsProviderTest(unittest.TestCase):
@@ -15,33 +15,33 @@ class CEmissionsProviderTest(unittest.TestCase):
         provider = CEmissionsProvider(CubeConfig(), SOURCE_DIR)
         provider.prepare()
         source_time_ranges = provider.get_source_time_ranges()
-        self.assertEqual(216, len(source_time_ranges))
-        self.assertEqual((datetime(1996, 1, 1, 0, 0, 0, 33),
-                          datetime(1996, 2, 1, 0, 0, 0, 33),
-                          os.path.join(SOURCE_DIR, 'C_Emissions.1440.720.12.1996.nc.gz'),
+        self.assertEqual(120, len(source_time_ranges))
+        self.assertEqual((datetime(2001, 1, 1, 0, 0),
+                          datetime(2001, 2, 1, 0, 0),
+                          os.path.join(SOURCE_DIR, 'fire_C_Emissions.nc'),
                           0), source_time_ranges[0])
-        self.assertEqual((datetime(1996, 7, 1, 0, 0, 0, 33),
-                          datetime(1996, 8, 1, 0, 0, 0, 33),
-                          os.path.join(SOURCE_DIR, 'C_Emissions.1440.720.12.1996.nc.gz'),
-                          6), source_time_ranges[6])
-        self.assertEqual((datetime(2013, 12, 1, 0, 0, 0, 33),
-                          datetime(2014, 1, 1, 0, 0, 0, 33),
-                          os.path.join(SOURCE_DIR, 'C_Emissions.1440.720.12.2013.nc.gz'),
-                          11), source_time_ranges[215])
+        self.assertEqual((datetime(2001, 12, 1, 0, 0),
+                          datetime(2002, 1, 1, 0, 0),
+                          os.path.join(SOURCE_DIR, 'fire_C_Emissions.nc'),
+                          11), source_time_ranges[11])
+        self.assertEqual((datetime(2010, 12, 1, 0, 0),
+                          datetime(2011, 1, 1, 0, 0),
+                          os.path.join(SOURCE_DIR, 'fire_C_Emissions.nc'),
+                          119), source_time_ranges[119])
 
     @unittest.skipIf(not os.path.exists(SOURCE_DIR), 'test data not found: ' + SOURCE_DIR)
     def test_temporal_coverage(self):
         provider = CEmissionsProvider(CubeConfig(), SOURCE_DIR)
         provider.prepare()
-        self.assertEqual((datetime(1996, 1, 1, 0, 0, 0, 33), datetime(2014, 1, 1, 0, 0, 0, 33)),
+        self.assertEqual((datetime(2001, 1, 1, 0, 0), datetime(2011, 1, 1, 0, 0)),
                          provider.get_temporal_coverage())
 
     @unittest.skipIf(not os.path.exists(SOURCE_DIR), 'test data not found: ' + SOURCE_DIR)
     def test_get_images(self):
         provider = CEmissionsProvider(CubeConfig(), SOURCE_DIR)
         provider.prepare()
-        images = provider.compute_variable_images(datetime(1996, 1, 1), datetime(1996, 1, 9))
+        images = provider.compute_variable_images(datetime(2001, 1, 1), datetime(2001, 1, 9))
         self.assertIsNotNone(images)
-        self.assertTrue('C_Emissions' in images)
-        image = images['C_Emissions']
+        self.assertTrue('Emission' in images)
+        image = images['Emission']
         self.assertEqual((720, 1440), image.shape)


### PR DESCRIPTION
Don't merge yet. I tried to fix the C Emission provider so that it works for the new Fire C emission input file. I still have a question, I somehow can not run the unit tests, I think they are just skipped. 
When I just try to run the test file from PyCharm I get the following output:

````
/Users/fgans/anaconda/bin/python "/Applications/PyCharm CE.app/Contents/helpers/pycharm/noserunner.py" /Users/fgans/scratch/cablab-core/test/providers/test_c_emissions.py
Testing started at 15:30 ...

Skip
S



Skip
S



Skip
S

----------------------------------------------------------------------
Ran 3 tests in 0.001s

OK (SKIP=3)


Process finished with exit code 0
````

What would be the correct way to run the unit test?