### PR TITLE
Fix aggregation

### DIFF
--- a/cablab/util.py
+++ b/cablab/util.py
@@ -54,12 +54,9 @@ def aggregate_images(images, weights=None):
     for i in range(len(images)):
         image = images[i]
         reshaped_image = image.reshape((1,) + image.shape)
-        if weights:
-            # reshaped_image *= weights[i]
-            numpy.multiply(reshaped_image, weights[i], out=reshaped_image, casting='unsafe')
         reshaped_images.append(reshaped_image)
         image_stack = numpy.ma.concatenate(reshaped_images)
-    return numpy.ma.average(image_stack, axis=0)
+    return numpy.ma.average(image_stack, axis=0, weights=weights)
 
     # aggregated_images = numpy.ma.zeros(images[0].shape,dtype = numpy.float32)
     # for i in range(len(images)):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -5,6 +5,7 @@ import numpy
 from cablab.util import aggregate_images
 from cablab.util import temporal_weight
 from cablab.util import resolve_temporal_range_index
+from cablab.util import aggregate_images
 
 from datetime import datetime
 
@@ -47,9 +48,16 @@ class UtilTest(unittest.TestCase):
         self.assertTrue(numpy.ma.is_masked(im))
 
         self.assertAlmostEqual(im[0][0], 2.2, places=3)
-        self.assertAlmostEqual(im[0][1], (0.5 * 2.1 + 0.25 * 4.3) / 2, places=4)
+        self.assertAlmostEqual(im[0][1], (0.5 * 2.1 + 0.25 * 4.3) / 0.75, places=4)
         self.assertIs(im[1][0], numpy.ma.masked)
-        self.assertAlmostEqual(im[1][1], (0.5 * 4.1 + 1.0 * 5.2 + 0.25 * 6.3) / 3, places=3)
+        self.assertAlmostEqual(im[1][1], (0.5 * 4.1 + 1.0 * 5.2 + 0.25 * 6.3) / 1.75, places=3)
+
+        im1 = numpy.zeros((3,3))
+        im2 = numpy.ones((3,3))
+
+        im = aggregate_images((im1,im2), weights = (0.25,0.75))
+
+        self.assertEqual(im[0][0],0.75)
 
     def test_resolve_temporal_range_index(self):
         time1_index, time2_index = resolve_temporal_range_index(2001, 2011, 8,


### PR DESCRIPTION
When making a test prototype colombia cube there was some strange behavior when aggregating monthly datasets to the 8day resolution. I think it was related to a bug in the `aggregate_images` function for which I propose this fix. 

I had to modify 2 existing unit tests, please check but I think they are correct now. A weighted average is the sum of the weight-multiplied values divided by the sum of the weights, not the number of values.
