### PR TITLE
change delimiter so it does not clash with windows file path

### DIFF
--- a/cablab/cube_gen.py
+++ b/cablab/cube_gen.py
@@ -27,7 +27,7 @@ SOURCE_PROVIDERS = _load_source_providers()
 
 def _parse_source_arg(source: str):
     from collections import OrderedDict
-    parts = source.split(';')
+    parts = source.split(os.pathsep)
     name = parts[0]
     if not name:
         return name, None, None, 'SOURCE name must not be empty'

--- a/cablab/cube_gen.py
+++ b/cablab/cube_gen.py
@@ -27,7 +27,7 @@ SOURCE_PROVIDERS = _load_source_providers()
 
 def _parse_source_arg(source: str):
     from collections import OrderedDict
-    parts = source.split(':')
+    parts = source.split(';')
     name = parts[0]
     if not name:
         return name, None, None, 'SOURCE name must not be empty'


### PR DESCRIPTION
Old command:

`cube-gen "<cube_path>\high-res" "burnt_area:dir=<source_dir>\BurntArea"`

However, when **source_dir** is **C:\\** , it will be wrongly parsed.

The proposed solution is to change the delimiter to `;` so that it does not clash with any characters in the Windows file path. The new command will look like:

`cube-gen "<cube_path>\high-res" "burnt_area;dir=<source_dir>\BurntArea"`

OR

`cube-gen "<cube_path>\low-res" "gross_primary_production;dir=<source_dir>\MPI_BGC\GPP;var=GPPall"`